### PR TITLE
Add pedantic C++ compiler warnings to CI

### DIFF
--- a/test/kitchen_sink/kitchen_sink_cpp.cpp
+++ b/test/kitchen_sink/kitchen_sink_cpp.cpp
@@ -1,1 +1,4 @@
+#pragma GCC diagnostic error "-Wall"
+#pragma GCC diagnostic error "-Wextra"
+#include <hardware/pio_instructions.h>
 #include "kitchen_sink.c"


### PR DESCRIPTION
The SDK can be used with C and C++ code.  With C++, though, additional warnings can be generated for things that are clean C.

This PR adds a simple -Wall -Wextra to the kitchen sink C++ compile test run as part of CI.

_Instructions: (please delete)_
 - _please do not submit against `master`, use `develop` instead_
 - _please make sure there is an associated issue for your PR, and reference it via "Fixes #num" in the description_
 - _please enter a detailed description_
